### PR TITLE
feat: support viewing draft questions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ BASE_URL=http://localhost:8080
 # get from Airtable if you have access, otherwise ask the Tech Lead
 AIRTABLE_API_KEY=
 AIRTABLE_BASE_ID=
+
+# delete or set to false if you don't want to see draft questions
+VIEW_DRAFTS=true

--- a/pages/_data/questionData.js
+++ b/pages/_data/questionData.js
@@ -9,12 +9,13 @@ Airtable.configure({
 });
 
 const base = Airtable.base(process.env.AIRTABLE_BASE_ID);
+const viewDrafts = process.env.VIEW_DRAFTS === 'true';
 
-const getPublishedQuestions = async () => {
+const getQuestions = async () => {
   const questions = await base('Questions and Answers').select().all();
 
   const publishedQuestions = questions
-    .filter((record) => record.fields.Published)
+    .filter((record) => record.fields.Published || viewDrafts)
     .map((record) => record.fields);
 
   return publishedQuestions;
@@ -52,7 +53,7 @@ const groupQuestionsIntoCategories = async (questions) => {
 };
 
 module.exports = async () => {
-  const questions = await getPublishedQuestions();
+  const questions = await getQuestions();
   const categories = getUniqueCategories(questions);
   const questionGroups = await groupQuestionsIntoCategories(questions);
 


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work supports viewing drafted questions in development by setting an environment variable.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Set `VIEW_DRAFTS=true` in your `.env` file
4. Run `npm start`
5. Confirm that you can see questions that have not been published in Airtable
6. Check the deploy preview and make sure you only see published questions
<!-- Add additional validation steps here -->
