### PR TITLE
feat: dynamically generate sitemap from question data

### DIFF
--- a/pages/all-questions/index.njk
+++ b/pages/all-questions/index.njk
@@ -1,6 +1,7 @@
 ---
 permalink:
   on-demand: /all-questions/:questionNumber/
+eleventyExcludeFromCollections: true
 ---
 
 {% extends 'layout.njk' %}

--- a/pages/questions/index.njk
+++ b/pages/questions/index.njk
@@ -1,6 +1,7 @@
 ---
 permalink:
   on-demand: /questions/:tag/:questionNumber/
+eleventyExcludeFromCollections: true
 ---
 
 {% extends 'layout.njk' %}

--- a/pages/sitemap.njk
+++ b/pages/sitemap.njk
@@ -10,4 +10,16 @@ eleventyExcludeFromCollections: true
       <lastmod>{{ page.date.toISOString() }}</lastmod>
     </url>
   {% endfor %}
+  {% for question in questionData.questions %}
+    <url>
+      <loc>{{ processEnv.BASE_URL }}/all-questions/{{ loop.index }}/</loc>
+    </url>
+  {% endfor %}
+  {% for tag, questionGroup in questionData.questionGroups %}
+    {% for question in questionGroup.questions %}
+      <url>
+        <loc>{{ processEnv.BASE_URL }}/questions/{{ tag }}/{{ loop.index }}/</loc>
+      </url>
+    {% endfor %}
+  {% endfor %}
 </urlset>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work generates the sitemap at build time using question data rather than its default behavior of using collections.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Check the generated output in `dist/sitemap.xml` and confirm it matches what you would expect
5. Check the deploy preview's sitemap and confirm that it is also correct
<!-- Add additional validation steps here -->
