### PR TITLE
feat: support multiple choice questions

### DIFF
--- a/pages/_data/questionData.js
+++ b/pages/_data/questionData.js
@@ -16,7 +16,37 @@ const getQuestions = async () => {
 
   const publishedQuestions = questions
     .filter((record) => record.fields.Published || viewDrafts)
-    .map((record) => record.fields);
+    .map((record) => {
+      const options = [
+        {
+          answer: record.fields.Answer,
+          isCorrect: true,
+        },
+      ];
+
+      if (record.fields['Distractor 1']) {
+        options.push({
+          answer: record.fields['Distractor 1'],
+          isCorrect: false,
+        });
+      }
+
+      if (record.fields['Distractor 2']) {
+        options.push({
+          answer: record.fields['Distractor 2'],
+          isCorrect: false,
+        });
+      }
+
+      return {
+        ...record.fields,
+        options: options.sort(() => {
+          const sign = Math.round(Math.random()) > 0 ? 1 : -1;
+
+          return sign;
+        }),
+      };
+    });
 
   return publishedQuestions;
 };

--- a/pages/all/multiple-choice/index.njk
+++ b/pages/all/multiple-choice/index.njk
@@ -1,0 +1,42 @@
+---
+pagination:
+  data: questionData.questions
+  size: 1
+  alias: question
+permalink: /all/multiple-choice/{{ pagination.pageNumber + 1 }}/
+eleventyExcludeFromCollections: true
+---
+
+{% extends 'layout.njk' %}
+
+{% set questionTotal = questionData.questions.length %}
+
+{% block titleAndDescription %}
+  <title>Question {{ pagination.pageNumber + 1 }} of {{ questionTotal }} | All Questions | Trivia11y</title>
+  <meta name="description" content="Answer question {{ pagination.pageNumber + 1 }} of {{ questionTotal }} in all categories.">
+{% endblock %}
+
+{% block content %}
+  <h1>Question {{ pagination.pageNumber + 1 }} of {{ questionTotal }}</h1>
+
+  {% from 'macros/multiple-choice.njk' import multipleChoice %}
+  {{ multipleChoice(question) }}
+
+  <div class="cmp-pagination">
+    {% if pagination.pageNumber + 1 > 1 %}
+      <a href="/all/multiple-choice/{{ pagination.pageNumber }}/">
+        Previous Question
+      </a>
+    {% else %}
+      <span></span>
+    {% endif %}
+
+    {% if questionTotal > pagination.pageNumber + 1 %}
+      <a href="/all/multiple-choice/{{ pagination.pageNumber + 2 }}/">
+        Next Question
+      </a>
+    {% else %}
+      <span></span>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/pages/all/multiple-choice/index.njk
+++ b/pages/all/multiple-choice/index.njk
@@ -40,3 +40,9 @@ eleventyExcludeFromCollections: true
     {% endif %}
   </div>
 {% endblock %}
+
+{% block scripts %}
+  <script>
+    {% include 'js/multiple-choice.js' %}
+  </script>
+{% endblock %}

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -9,7 +9,7 @@ layout: default
 <h2>Flash Cards</h2>
 
 <p>
-  Choose a category in which to review your knowledge flash card style.
+  Choose a category in which to review your knowledge, flash card style.
 </p>
 
 <ul class="cmp-categories">
@@ -21,6 +21,28 @@ layout: default
 {% for category in questionData.flashCardCategories %}
   <li>
     <a href="/flash-cards/{{ category | slugify }}/1/">
+      {{ category }}
+    </a>
+  </li>
+{% endfor %}
+</ul>
+
+
+<h2>Multiple Choice</h2>
+
+<p>
+  Choose a category in which to review your knowledge, multiple choice style.
+</p>
+
+<ul class="cmp-categories">
+  <li>
+    <a href="/all/multiple-choice/1/">
+      All Questions
+    </a>
+  </li>
+{% for category in questionData.categories %}
+  <li>
+    <a href="/multiple-choice/{{ category | slugify }}/1/">
       {{ category }}
     </a>
   </li>

--- a/pages/multiple-choice/index.njk
+++ b/pages/multiple-choice/index.njk
@@ -38,3 +38,9 @@ eleventyExcludeFromCollections: true
     {% endif %}
   </div>
 {% endblock %}
+
+{% block scripts %}
+  <script>
+    {% include 'js/multiple-choice.js' %}
+  </script>
+{% endblock %}

--- a/pages/multiple-choice/index.njk
+++ b/pages/multiple-choice/index.njk
@@ -1,0 +1,40 @@
+---
+pagination:
+  data: questionData.questionGroups
+  size: 1
+  alias: questionGroup
+permalink: /multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber }}/
+eleventyExcludeFromCollections: true
+---
+
+{% extends 'layout.njk' %}
+
+{% block titleAndDescription %}
+  <title>Question {{ questionGroup.pageNumber }} of {{ questionGroup.questionTotal }} | {{ questionGroup.category }} | Trivia11y</title>
+  <meta name="description" content="Answer question {{ questionGroup.pageNumber }} of {{ questionGroup.questionTotal }} about {{ questionGroup.category }}.">
+{% endblock %}
+
+{% block content %}
+  <h1>{{ questionGroup.category }}: Question {{ questionGroup.pageNumber }} of {{ questionGroup.questionTotal }}</h1>
+
+  {% from 'macros/multiple-choice.njk' import multipleChoice %}
+  {{ multipleChoice(questionGroup.question) }}
+
+  <div class="cmp-pagination">
+    {% if questionGroup.pageNumber > 1 %}
+      <a href="/multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/">
+        Previous Question
+      </a>
+    {% else %}
+      <span></span>
+    {% endif %}
+
+    {% if questionGroup.questionTotal > questionGroup.pageNumber %}
+      <a href="/multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/">
+        Next Question
+      </a>
+    {% else %}
+      <span></span>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/pages/styles.njk
+++ b/pages/styles.njk
@@ -9,7 +9,9 @@ eleventyExcludeFromCollections: true
 {% include 'css/elements.header.css' %}
 {% include 'css/components.container.css' %}
 {% include 'css/components.stack.css' %}
+{% include 'css/components.switcher.css' %}
 {% include 'css/components.pagination.css' %}
 {% include 'css/components.question.css' %}
 {% include 'css/components.answer.css' %}
 {% include 'css/components.categories.css' %}
+{% include 'css/components.option.css' %}

--- a/src/css/components.answer.css
+++ b/src/css/components.answer.css
@@ -17,3 +17,7 @@
   margin: 0;
   font-size: clamp(1rem, 1rem + 1vw, 2rem);
 }
+
+.cmp-answer p:not(:first-child) {
+  margin-block-start: 1rem;
+}

--- a/src/css/components.categories.css
+++ b/src/css/components.categories.css
@@ -5,3 +5,7 @@
   flex-direction: column;
   gap: 1rem;
 }
+
+.cmp-categories a {
+  font-size: clamp(1rem, 1rem + 0.5vw, 1.5rem);
+}

--- a/src/css/components.option.css
+++ b/src/css/components.option.css
@@ -1,0 +1,22 @@
+.cmp-option-button {
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  width: 100%;
+  background-color: var(--paper);
+  color: var(--ink);
+  font-size: clamp(1rem, 1rem + 1vw, 2rem);
+  font-weight: 700;
+  border: 0.125rem solid var(--ink);
+  border-radius: 0.25rem;
+  box-shadow: 0.25rem 0.25rem 0 0 var(--shadow);
+}
+
+.cmp-option-button[aria-pressed='true'] {
+  box-shadow: none;
+  border-color: var(--incorrect);
+}
+
+.cmp-option-button[aria-pressed='true'][data-correct='true'] {
+  box-shadow: none;
+  border-color: var(--correct);
+}

--- a/src/css/components.pagination.css
+++ b/src/css/components.pagination.css
@@ -4,3 +4,7 @@
   gap: 2rem;
   justify-content: space-between;
 }
+
+.cmp-pagination a {
+  font-size: clamp(1rem, 1rem + 0.5vw, 1.5rem);
+}

--- a/src/css/components.switcher.css
+++ b/src/css/components.switcher.css
@@ -1,0 +1,15 @@
+.cmp-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.cmp-switcher > * {
+  flex-grow: 1;
+  flex-basis: calc((30rem - 100%) * 999);
+}
+
+.cmp-switcher > :nth-last-child(n + 5),
+.cmp-switcher > :nth-last-child(n + 5) ~ * {
+  flex-basis: 100%;
+}

--- a/src/css/elements.a.css
+++ b/src/css/elements.a.css
@@ -1,4 +1,3 @@
 a {
   color: currentcolor;
-  font-size: clamp(1rem, 1rem + 0.5vw, 1.5rem);
 }

--- a/src/css/elements.header.css
+++ b/src/css/elements.header.css
@@ -1,3 +1,7 @@
 header {
   padding-block: 1rem;
 }
+
+header a {
+  font-size: clamp(1rem, 1rem + 0.5vw, 1.5rem);
+}

--- a/src/css/elements.root.css
+++ b/src/css/elements.root.css
@@ -1,6 +1,9 @@
 :root {
   --ink: hsl(0deg 0% 5%);
   --paper: hsl(0deg 0% 95%);
+  --shadow: #999;
+  --correct: forestgreen;
+  --incorrect: tomato;
 
   color: var(--ink);
   background-color: var(--paper);
@@ -10,5 +13,8 @@
   :root {
     --ink: hsl(0deg 0% 95%);
     --paper: hsl(0deg 0% 5%);
+    --shadow: #444;
+    --correct: forestgreen;
+    --incorrect: tomato;
   }
 }

--- a/src/js/multiple-choice.js
+++ b/src/js/multiple-choice.js
@@ -1,0 +1,22 @@
+const optionButtons = document.querySelectorAll('.cmp-option-button');
+const explanation = document.querySelector('#explanation');
+const liveRegion = document.querySelector('[aria-live]');
+
+const handleOptionButtonClick = (event) => {
+  const isPressed = event.target.getAttribute('aria-pressed') === 'true';
+  const isCorrect = event.target.dataset.correct === 'true';
+  const explanationContent = explanation.innerHTML;
+
+  optionButtons.forEach((button) => {
+    button.setAttribute('aria-pressed', 'false');
+  });
+
+  event.target.setAttribute('aria-pressed', isPressed ? 'false' : 'true');
+  liveRegion.innerHTML = `<p>${
+    isCorrect ? 'Correct' : 'Incorrect'
+  }</p>${explanationContent}`;
+};
+
+optionButtons.forEach((button) => {
+  button.addEventListener('click', handleOptionButtonClick);
+});

--- a/src/js/multiple-choice.js
+++ b/src/js/multiple-choice.js
@@ -1,6 +1,6 @@
 const optionButtons = document.querySelectorAll('.cmp-option-button');
 const explanation = document.querySelector('#explanation');
-const liveRegion = document.querySelector('[aria-live]');
+const explanationSection = document.querySelector('#explanationSection');
 
 const handleOptionButtonClick = (event) => {
   const isPressed = event.target.getAttribute('aria-pressed') === 'true';
@@ -12,9 +12,10 @@ const handleOptionButtonClick = (event) => {
   });
 
   event.target.setAttribute('aria-pressed', isPressed ? 'false' : 'true');
-  liveRegion.innerHTML = `<p>${
+  explanationSection.innerHTML = `<p>${
     isCorrect ? 'Correct' : 'Incorrect'
   }</p>${explanationContent}`;
+  explanationSection.focus();
 };
 
 optionButtons.forEach((button) => {

--- a/src/macros/flash-card.njk
+++ b/src/macros/flash-card.njk
@@ -8,6 +8,9 @@
     </summary>
     <div>
       {{ question.Answer | mdToHtml | safe }}
+      {% if question.Explanation %}
+        {{ question.Explanation | mdToHtml | safe }}
+      {% endif %}
     </div>
   </details>
 {% endmacro %}

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -20,7 +20,7 @@
       </div>
     {% endfor %}
   </div>
-  <div role="region" aria-live="polite"></div>
+  <div id="explanationSection" tabindex="-1"></div>
   <template id="explanation">
     {% if question.Explanation %}
       {{ question.Explanation | mdToHtml | safe }}

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -4,8 +4,8 @@
   </div>
   <div class="cmp-switcher">
     {% for option in question.options %}
-      <div class="cmp-option">
-        <button type="button" class="cmp-option__button" aria-pressed="false" aria-describedby="option-{{ loop.index }}" data-correct="{{ option.isCorrect }}">
+      <div>
+        <button type="button" class="cmp-option-button" aria-pressed="false" aria-describedby="option-{{ loop.index }}" data-correct="{{ option.isCorrect }}">
           {% if loop.index === 1 %}
             A
           {% elseif loop.index === 2 %}
@@ -14,7 +14,7 @@
             C
           {% endif %}
         </button>
-        <div id="option-{{ loop.index }}" class="cmp-option__answer">
+        <div id="option-{{ loop.index }}">
           {{ option.answer | mdToHtml | safe }}
         </div>
       </div>

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -20,4 +20,10 @@
       </div>
     {% endfor %}
   </div>
+  <div role="region" aria-live="polite"></div>
+  <template id="explanation">
+    {% if question.Explanation %}
+      {{ question.Explanation | mdToHtml | safe }}
+    {% endif %}
+  </template>
 {% endmacro %}

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -1,0 +1,23 @@
+{% macro multipleChoice(question) %}
+  <div class="cmp-question">
+    {{ question.Question | mdToHtml | safe }}
+  </div>
+  <div class="cmp-switcher">
+    {% for option in question.options %}
+      <div class="cmp-option">
+        <button type="button" class="cmp-option__button" aria-pressed="false" aria-describedby="option-{{ loop.index }}" data-correct="{{ option.isCorrect }}">
+          {% if loop.index === 1 %}
+            A
+          {% elseif loop.index === 2 %}
+            B
+          {% else %}
+            C
+          {% endif %}
+        </button>
+        <div id="option-{{ loop.index }}" class="cmp-option__answer">
+          {{ option.answer | mdToHtml | safe }}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endmacro %}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['stylelint-config-standard'],
+  rules: {
+    'selector-class-pattern': null,
+  },
 };


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work adds a separate mode of answering questions via multiple choice. The URLs follow the same structure as the flash cards, but with `/multiple-choice/` in the path segment, and they show up to 3 options (in a randomized order determined at build-time).

When an incorrect answer is clicked, focus moves to a `div` that includes a paragraph that says "Incorrect, followed by an explanation if one is provided. If the correct answer is clicked, that `div` is updated with "Correct" followed by the explanation.

Since the multiple choice answers may not be phrasing content, the button text is either "A", "B", or "C", but each button has an `aria-describedby` attribute pointing to the element containing the corresponding answer. The buttons also use `aria-pressed`, which is used for both styling (highlighting which answer they chose) and communicating the user's selection to screen readers.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Click/tab through the multiple choice questions under "All Questions" and make sure everything works as expected
5. Do the same for multiple choice questions by category
<!-- Add additional validation steps here -->
